### PR TITLE
Add fund registry data stores

### DIFF
--- a/src/services/dataStore.js
+++ b/src/services/dataStore.js
@@ -6,7 +6,7 @@
  */
 
 const DB_NAME = 'LightshipFundAnalysis';
-const DB_VERSION = 2; // Incremented for new stores
+const DB_VERSION = 3; // Incremented for new stores
 
 // Object store names
 const STORES = {
@@ -20,6 +20,9 @@ const STORES = {
     FUND_VERSIONS: 'fundVersions',
     BENCHMARK_HISTORY: 'benchmarkHistory'
   };
+
+// Utility to clean fund symbols consistently
+const clean = (s) => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
 
 // Initialize database connection
 let db = null;
@@ -69,12 +72,46 @@ async function openDB() {
 
       // Create audit log store
       if (!database.objectStoreNames.contains(STORES.AUDIT_LOG)) {
-        const auditStore = database.createObjectStore(STORES.AUDIT_LOG, { 
+        const auditStore = database.createObjectStore(STORES.AUDIT_LOG, {
           keyPath: 'id',
-          autoIncrement: true 
+          autoIncrement: true
         });
         auditStore.createIndex('timestamp', 'timestamp', { unique: false });
         auditStore.createIndex('action', 'action', { unique: false });
+      }
+
+      // Create fund registry store
+      if (!database.objectStoreNames.contains(STORES.FUND_REGISTRY)) {
+        database.createObjectStore(STORES.FUND_REGISTRY, { keyPath: 'symbol' });
+      }
+
+      // Create fund history store
+      if (!database.objectStoreNames.contains(STORES.FUND_HISTORY)) {
+        const historyStore = database.createObjectStore(STORES.FUND_HISTORY, {
+          keyPath: 'id',
+          autoIncrement: true
+        });
+        historyStore.createIndex('symbol', 'symbol', { unique: false });
+        historyStore.createIndex('timestamp', 'timestamp', { unique: false });
+      }
+
+      // Create fund versions store
+      if (!database.objectStoreNames.contains(STORES.FUND_VERSIONS)) {
+        const versionStore = database.createObjectStore(STORES.FUND_VERSIONS, {
+          keyPath: 'id',
+          autoIncrement: true
+        });
+        versionStore.createIndex('timestamp', 'timestamp', { unique: false });
+      }
+
+      // Create benchmark history store
+      if (!database.objectStoreNames.contains(STORES.BENCHMARK_HISTORY)) {
+        const benchmarkStore = database.createObjectStore(STORES.BENCHMARK_HISTORY, {
+          keyPath: 'id',
+          autoIncrement: true
+        });
+        benchmarkStore.createIndex('assetClass', 'assetClass', { unique: false });
+        benchmarkStore.createIndex('timestamp', 'timestamp', { unique: false });
       }
     };
   });
@@ -502,11 +539,24 @@ export async function compareSnapshots(snapshotId1, snapshotId2) {
  * @returns {Promise<Object>} All data
  */
 export async function exportAllData() {
-  const [snapshots, config, preferences, auditLog] = await Promise.all([
+  const [
+    snapshots,
+    config,
+    preferences,
+    auditLog,
+    funds,
+    benchmarks,
+    fundHistory,
+    fundVersions
+  ] = await Promise.all([
     getAllSnapshots(),
     getAllConfig(),
     getAllPreferences(),
-    getAuditLog(1000)
+    getAuditLog(1000),
+    getAllFunds(false),
+    getAllBenchmarks(),
+    getFundHistory(null, 1000),
+    getFundVersions(100)
   ]);
   
   return {
@@ -515,7 +565,11 @@ export async function exportAllData() {
     snapshots,
     config,
     preferences,
-    auditLog
+    auditLog,
+    funds,
+    benchmarks,
+    fundHistory,
+    fundVersions
   };
 }
 
@@ -549,10 +603,52 @@ export async function importData(data) {
       await savePreference(item.key, item.value);
     }
   }
+
+  // Import funds
+  if (data.funds) {
+    for (const fund of data.funds) {
+      await saveFund(fund);
+    }
+  }
+
+  // Import benchmarks
+  if (data.benchmarks) {
+    for (const b of data.benchmarks) {
+      await saveBenchmark({
+        assetClass: b.assetClass,
+        ticker: b.ticker,
+        name: b.name,
+        changedBy: 'import'
+      });
+    }
+  }
+
+  // Import fund history
+  if (data.fundHistory) {
+    for (const entry of data.fundHistory) {
+      await addFundHistoryEntry(entry);
+    }
+  }
+
+  // Import versions
+  if (data.fundVersions) {
+    const db = await openDB();
+    const tx = db.transaction([STORES.FUND_VERSIONS], 'readwrite');
+    const store = tx.objectStore(STORES.FUND_VERSIONS);
+    for (const v of data.fundVersions) {
+      await new Promise((resolve, reject) => {
+        const req = store.put(v);
+        req.onsuccess = () => resolve();
+        req.onerror = () => reject(req.error);
+      });
+    }
+  }
   
-  logAction('data_imported', { 
+  logAction('data_imported', {
     snapshotsCount: data.snapshots?.length || 0,
-    configCount: data.config?.length || 0
+    configCount: data.config?.length || 0,
+    funds: data.funds?.length || 0,
+    benchmarks: data.benchmarks?.length || 0
   });
 }
 
@@ -594,13 +690,318 @@ async function getAllPreferences() {
 }
 
 /**
+ * Get all funds in the registry
+ * @param {boolean} activeOnly - Only return active funds
+ * @returns {Promise<Array>} Funds
+ */
+export async function getAllFunds(activeOnly = false) {
+  const database = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction([STORES.FUND_REGISTRY], 'readonly');
+    const store = transaction.objectStore(STORES.FUND_REGISTRY);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      let funds = request.result || [];
+      if (activeOnly) {
+        funds = funds.filter(f => f.status === 'active');
+      }
+      resolve(funds);
+    };
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+}
+
+/**
+ * Get a single fund by symbol
+ * @param {string} symbol - Fund symbol
+ * @returns {Promise<Object|null>} Fund data or null
+ */
+export async function getFund(symbol) {
+  const database = await openDB();
+  const cleanSymbol = clean(symbol);
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction([STORES.FUND_REGISTRY], 'readonly');
+    const store = transaction.objectStore(STORES.FUND_REGISTRY);
+    const request = store.get(cleanSymbol);
+
+    request.onsuccess = () => resolve(request.result || null);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Save or update a fund
+ * @param {Object} fund - Fund object
+ * @returns {Promise<string>} Saved symbol
+ */
+export async function saveFund(fund) {
+  const database = await openDB();
+  const symbol = clean(fund.symbol);
+
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_REGISTRY], 'readwrite');
+    const store = tx.objectStore(STORES.FUND_REGISTRY);
+
+    const data = { ...fund, symbol, lastModified: new Date().toISOString() };
+    const request = store.put(data);
+
+    request.onsuccess = () => {
+      logAction('fund_saved', { symbol });
+      resolve(symbol);
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Remove (soft delete) a fund and record history
+ * @param {string} symbol - Fund symbol
+ * @param {string} reason - Removal reason
+ * @param {string} user - User performing action
+ */
+export async function removeFund(symbol, reason, user) {
+  const fund = await getFund(symbol);
+  if (!fund) return;
+
+  const newState = {
+    ...fund,
+    status: 'removed',
+    removedDate: new Date().toISOString(),
+    removedBy: user,
+    removedReason: reason,
+    lastModified: new Date().toISOString()
+  };
+
+  await saveFund(newState);
+
+  await addFundHistoryEntry({
+    symbol: clean(symbol),
+    action: 'removed',
+    previousState: fund,
+    newState,
+    reason,
+    changedBy: user
+  });
+
+  logAction('fund_removed', { symbol: clean(symbol), reason });
+}
+
+/**
+ * Add entry to fund history
+ * @param {Object} entry - History entry
+ */
+export async function addFundHistoryEntry(entry) {
+  const database = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_HISTORY], 'readwrite');
+    const store = tx.objectStore(STORES.FUND_HISTORY);
+    const data = { ...entry, timestamp: new Date().toISOString() };
+    const request = store.add(data);
+
+    request.onsuccess = () => {
+      logAction('fund_history_added', { symbol: entry.symbol, action: entry.action });
+      resolve();
+    };
+
+    request.onerror = () => {
+      reject(request.error);
+    };
+  });
+}
+
+/**
+ * Get fund history
+ * @param {string|null} symbol - Symbol filter
+ * @param {number} limit - Max entries
+ * @returns {Promise<Array>} History
+ */
+export async function getFundHistory(symbol = null, limit = 100) {
+  const database = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_HISTORY], 'readonly');
+    const store = tx.objectStore(STORES.FUND_HISTORY);
+    const index = symbol ? store.index('symbol') : store.index('timestamp');
+    const key = symbol ? IDBKeyRange.only(clean(symbol)) : null;
+    const request = index.openCursor(key, 'prev');
+
+    const results = [];
+
+    request.onsuccess = (event) => {
+      const cursor = event.target.result;
+      if (cursor && results.length < limit) {
+        results.push(cursor.value);
+        cursor.continue();
+      } else {
+        resolve(results);
+      }
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Save benchmark mapping and log history
+ * @param {Object} obj - Benchmark info
+ */
+export async function saveBenchmark(obj) {
+  const database = await openDB();
+
+  // Update config mapping
+  const existing = (await getConfig('assetClassBenchmarks')) || {};
+  existing[obj.assetClass] = { ticker: obj.ticker, name: obj.name };
+  await saveConfig('assetClassBenchmarks', existing);
+
+  // Add history entry
+  await new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.BENCHMARK_HISTORY], 'readwrite');
+    const store = tx.objectStore(STORES.BENCHMARK_HISTORY);
+    const entry = {
+      assetClass: obj.assetClass,
+      ticker: obj.ticker,
+      name: obj.name,
+      previousTicker: obj.previousTicker,
+      previousName: obj.previousName,
+      changedBy: obj.changedBy,
+      timestamp: new Date().toISOString()
+    };
+    const request = store.add(entry);
+    request.onsuccess = () => {
+      logAction('benchmark_updated', { assetClass: obj.assetClass, ticker: obj.ticker });
+      resolve();
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Get all benchmarks
+ * @returns {Promise<Array>} Benchmark list
+ */
+export async function getAllBenchmarks() {
+  const map = (await getConfig('assetClassBenchmarks')) || {};
+  return Object.keys(map).map(k => ({ assetClass: k, ticker: map[k].ticker, name: map[k].name }));
+}
+
+/**
+ * Create a version snapshot of the fund registry
+ * @param {string} message - Version message
+ * @param {string} author - Author name
+ * @returns {Promise<number>} Version ID
+ */
+export async function createFundVersion(message, author) {
+  const funds = await getAllFunds(false);
+  const database = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_VERSIONS], 'readwrite');
+    const store = tx.objectStore(STORES.FUND_VERSIONS);
+    const version = {
+      message,
+      author,
+      timestamp: new Date().toISOString(),
+      funds,
+      fundCount: funds.length,
+      activeFundCount: funds.filter(f => f.status === 'active').length
+    };
+    const request = store.add(version);
+    request.onsuccess = () => {
+      const id = request.result;
+      logAction('fund_version_created', { id, message });
+      resolve(id);
+    };
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Get list of fund versions
+ * @param {number} limit - Max versions
+ * @returns {Promise<Array>} Versions
+ */
+export async function getFundVersions(limit = 50) {
+  const database = await openDB();
+
+  return new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_VERSIONS], 'readonly');
+    const store = tx.objectStore(STORES.FUND_VERSIONS);
+    const index = store.index('timestamp');
+    const request = index.openCursor(null, 'prev');
+
+    const versions = [];
+
+    request.onsuccess = (event) => {
+      const cursor = event.target.result;
+      if (cursor && versions.length < limit) {
+        versions.push(cursor.value);
+        cursor.continue();
+      } else {
+        resolve(versions);
+      }
+    };
+
+    request.onerror = () => reject(request.error);
+  });
+}
+
+/**
+ * Restore fund registry from a version
+ * @param {number} id - Version ID
+ */
+export async function restoreFundVersion(id) {
+  const database = await openDB();
+
+  const version = await new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_VERSIONS], 'readonly');
+    const store = tx.objectStore(STORES.FUND_VERSIONS);
+    const req = store.get(id);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+  if (!version) throw new Error('Version not found');
+
+  await new Promise((resolve, reject) => {
+    const tx = database.transaction([STORES.FUND_REGISTRY], 'readwrite');
+    const store = tx.objectStore(STORES.FUND_REGISTRY);
+    const clearReq = store.clear();
+    clearReq.onsuccess = () => resolve();
+    clearReq.onerror = () => reject(clearReq.error);
+  });
+
+  for (const fund of version.funds) {
+    await saveFund(fund);
+  }
+
+  logAction('fund_version_restored', { id });
+}
+
+/**
  * Clear all data (for testing or reset)
  * @returns {Promise<void>}
  */
 export async function clearAllData() {
   const database = await openDB();
   
-  const stores = [STORES.SNAPSHOTS, STORES.CONFIG, STORES.PREFERENCES, STORES.AUDIT_LOG];
+  const stores = [
+    STORES.SNAPSHOTS,
+    STORES.CONFIG,
+    STORES.PREFERENCES,
+    STORES.AUDIT_LOG,
+    STORES.FUND_REGISTRY,
+    STORES.FUND_HISTORY,
+    STORES.FUND_VERSIONS,
+    STORES.BENCHMARK_HISTORY
+  ];
   const transaction = database.transaction(stores, 'readwrite');
   
   const promises = stores.map(storeName => {
@@ -630,5 +1031,16 @@ export default {
   compareSnapshots,
   exportAllData,
   importData,
-  clearAllData
+  clearAllData,
+  getAllFunds,
+  getFund,
+  saveFund,
+  removeFund,
+  addFundHistoryEntry,
+  getFundHistory,
+  saveBenchmark,
+  getAllBenchmarks,
+  createFundVersion,
+  getFundVersions,
+  restoreFundVersion
 };


### PR DESCRIPTION
## Summary
- add clean symbol util and upgrade DB schema to include fund stores
- implement fund, benchmark, history and version persistence methods
- expose new methods and include them in data import/export/clear

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686546e645cc8329967696ed78e82a9a