### PR TITLE
Handle 3/5 year StdDev columns

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -221,8 +221,17 @@ const App = () => {
             // Performance metrics
             if (header.includes('YTD')) columnMap['YTD'] = index;
             if (header.includes('1 Year') || header.includes('1 Yr')) columnMap['1 Year'] = index;
-            if (header.includes('3 Year') || header.includes('3 Yr')) columnMap['3 Year'] = index;
-            if (header.includes('5 Year') || header.includes('5 Yr')) columnMap['5 Year'] = index;
+            if ((header.includes('3 Year') || header.includes('3 Yr')) && header.toLowerCase().includes('deviation')) {
+              columnMap['StdDev3Y'] = index;
+            } else if (header.includes('3 Year') || header.includes('3 Yr')) {
+              columnMap['3 Year'] = index;
+            }
+
+            if ((header.includes('5 Year') || header.includes('5 Yr')) && header.toLowerCase().includes('deviation')) {
+              columnMap['StdDev5Y'] = index;
+            } else if (header.includes('5 Year') || header.includes('5 Yr')) {
+              columnMap['5 Year'] = index;
+            }
             if (header.includes('10 Year') || header.includes('10 Yr')) columnMap['10 Year'] = index;
             
             // Risk metrics
@@ -250,6 +259,10 @@ const App = () => {
             }
             fund[key] = isNaN(val) ? val : parseFloat(val);
           });
+          if (fund['Standard Deviation'] != null) {
+            if (fund['StdDev3Y'] == null) fund['StdDev3Y'] = fund['Standard Deviation'];
+            if (fund['StdDev5Y'] == null) fund['StdDev5Y'] = fund['Standard Deviation'];
+          }
           return fund;
         }).filter(f => f.Symbol && f.Symbol !== ''); // Filter out empty rows
 
@@ -1010,7 +1023,7 @@ const App = () => {
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>3Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>Sharpe</th>
-                    <th style={{ padding: '0.75rem', textAlign: 'right' }}>Std Dev</th>
+                    <th style={{ padding: '0.75rem', textAlign: 'right' }}>Std Dev 3Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>Expense</th>
                   </tr>
                 </thead>
@@ -1049,7 +1062,7 @@ const App = () => {
                         {benchmarkData[selectedClass]['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['Standard Deviation']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['StdDev3Y']?.toFixed(2) ?? 'N/A'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                         {benchmarkData[selectedClass]['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%
@@ -1099,7 +1112,7 @@ const App = () => {
                           {fund['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['Standard Deviation']?.toFixed(2) ?? 'N/A'}%
+                          {fund['StdDev3Y']?.toFixed(2) ?? 'N/A'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                           {fund['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%

--- a/src/services/analytics.js
+++ b/src/services/analytics.js
@@ -70,7 +70,7 @@ export function calculateCorrelation(x, y) {
    * @returns {number} Similarity score (0 to 1)
    */
   function calculateMetricSimilarity(fund1, fund2) {
-    const metrics = ['1 Year', '3 Year', '5 Year', 'Sharpe Ratio', 'Standard Deviation'];
+    const metrics = ['1 Year', '3 Year', '5 Year', 'Sharpe Ratio', 'StdDev3Y'];
     let validMetrics = 0;
     let totalDifference = 0;
     
@@ -101,7 +101,7 @@ export function calculateCorrelation(x, y) {
       const returnMetric = fund['3 Year'] || fund['1 Year'] || 0;
       
       // Use standard deviation as risk metric
-      const riskMetric = fund['Standard Deviation'] || 0;
+      const riskMetric = fund['StdDev3Y'] ?? fund['Standard Deviation'] || 0;
       
       // Calculate risk-adjusted return (similar to Sharpe but simplified)
       const riskAdjustedReturn = riskMetric > 0 ? returnMetric / riskMetric : 0;
@@ -171,7 +171,7 @@ export function calculateCorrelation(x, y) {
     funds.forEach(fund => {
       const weight = weights[fund.Symbol] || defaultWeight;
       const fundReturn = fund['3 Year'] || fund['1 Year'] || 0;
-      const fundRisk = fund['Standard Deviation'] || 0;
+      const fundRisk = fund['StdDev3Y'] ?? fund['Standard Deviation'] || 0;
       
       portfolioReturn += fundReturn * weight;
       portfolioRisk += fundRisk * weight; // Simplified - doesn't account for correlation
@@ -366,7 +366,7 @@ export function calculateCorrelation(x, y) {
     // Calculate means and standard deviations
     const metrics = {
       performance: funds.map(f => f['1 Year']).filter(v => v != null),
-      risk: funds.map(f => f['Standard Deviation']).filter(v => v != null),
+      risk: funds.map(f => f['StdDev3Y'] ?? f['Standard Deviation']).filter(v => v != null),
       expense: funds.map(f => f['Net Expense Ratio']).filter(v => v != null),
       score: funds.map(f => f.scores?.final).filter(v => v != null)
     };
@@ -386,7 +386,7 @@ export function calculateCorrelation(x, y) {
             value = fund['1 Year'];
             break;
           case 'risk':
-            value = fund['Standard Deviation'];
+            value = fund['StdDev3Y'] ?? fund['Standard Deviation'];
             break;
           case 'expense':
             value = fund['Net Expense Ratio'];

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -62,7 +62,8 @@ export function exportToExcel(data) {
     '5 Year %',
     '10 Year %',
     'Sharpe Ratio',
-    'Std Dev',
+    'Std Dev 3Y',
+    'Std Dev 5Y',
     'Expense Ratio %',
     'Manager Tenure',
     'Is Recommended',
@@ -82,7 +83,8 @@ export function exportToExcel(data) {
     fund['5 Year'] || '',
     fund['10 Year'] || '',
     fund['Sharpe Ratio'] || '',
-    fund['Standard Deviation'] || '',
+    fund['StdDev3Y'] || '',
+    fund['StdDev5Y'] || '',
     fund['Net Expense Ratio'] || '',
     fund['Manager Tenure'] || '',
     fund.isRecommended ? 'Yes' : 'No',
@@ -105,7 +107,8 @@ export function exportToExcel(data) {
     { wch: 8 },  // 5Y
     { wch: 8 },  // 10Y
     { wch: 12 }, // Sharpe
-    { wch: 10 }, // Std Dev
+    { wch: 10 }, // Std Dev 3Y
+    { wch: 10 }, // Std Dev 5Y
     { wch: 12 }, // Expense
     { wch: 12 }, // Tenure
     { wch: 12 }, // Recommended

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -163,8 +163,8 @@ const METRIC_WEIGHTS = {
       fiveYear: parseMetricValue(fundData['5 Year']),
       tenYear: parseMetricValue(fundData['10 Year']),
       sharpeRatio3Y: parseMetricValue(fundData['Sharpe Ratio']),
-      stdDev3Y: parseMetricValue(fundData['Standard Deviation']),
-      stdDev5Y: parseMetricValue(fundData['Standard Deviation']), // Using same as 3Y if 5Y not available
+      stdDev3Y: parseMetricValue(fundData['StdDev3Y'] ?? fundData['Standard Deviation']),
+      stdDev5Y: parseMetricValue(fundData['StdDev5Y'] ?? fundData['Standard Deviation']),
       upCapture3Y: parseMetricValue(fundData['Up Capture Ratio']),
       downCapture3Y: parseMetricValue(fundData['Down Capture Ratio']),
       alpha5Y: parseMetricValue(fundData['Alpha']),

--- a/src/services/tagEngine.js
+++ b/src/services/tagEngine.js
@@ -58,7 +58,7 @@ export const DEFAULT_TAG_RULES = [
       description: 'Standard deviation above asset class average by 20%',
       condition: (fund, context) => {
         const avgStdDev = context.assetClassAverages[fund['Asset Class']]?.avgStdDev;
-        return avgStdDev && fund['Standard Deviation'] > avgStdDev * 1.2;
+        return avgStdDev && (fund['StdDev3Y'] ?? fund['Standard Deviation']) > avgStdDev * 1.2;
       },
       color: '#ef4444',
       icon: '📊',
@@ -94,9 +94,9 @@ export const DEFAULT_TAG_RULES = [
       condition: (fund, context) => {
         // This would need historical data to calculate
         // For now, use a proxy: good score with low std dev
-        return fund.scores?.final >= 60 && 
-               fund['Standard Deviation'] != null &&
-               fund['Standard Deviation'] < 10;
+        return fund.scores?.final >= 60 &&
+               (fund['StdDev3Y'] ?? fund['Standard Deviation']) != null &&
+               (fund['StdDev3Y'] ?? fund['Standard Deviation']) < 10;
       },
       color: '#6366f1',
       icon: '🎯',
@@ -221,7 +221,7 @@ export const DEFAULT_TAG_RULES = [
         .filter(e => e != null);
       
       const stdDevs = classFunds
-        .map(f => f['Standard Deviation'])
+        .map(f => f['StdDev3Y'] ?? f['Standard Deviation'])
         .filter(s => s != null);
       
       const sharpes = classFunds


### PR DESCRIPTION
## Summary
- map 3Y and 5Y deviation columns when parsing uploaded files
- persist StdDev3Y and StdDev5Y values for each fund
- display StdDev3Y in class tables
- export both 3Y and 5Y standard deviation metrics
- factor new StdDev fields into scoring, analytics and tagging logic

## Testing
- `CI=true npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68658e9177cc8329a7cc1f344c7654e3