### PR TITLE
Add YTD and 5Y table columns

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -796,7 +796,9 @@ const App = () => {
                       <th style={{ textAlign: 'left', padding: '0.75rem', fontWeight: '600' }}>Fund Name</th>
                       <th style={{ textAlign: 'left', padding: '0.75rem', fontWeight: '600' }}>Asset Class</th>
                       <th style={{ textAlign: 'center', padding: '0.75rem', fontWeight: '600' }}>Score</th>
+                      <th style={{ textAlign: 'right', padding: '0.75rem', fontWeight: '600' }}>YTD</th>
                       <th style={{ textAlign: 'right', padding: '0.75rem', fontWeight: '600' }}>1Y Return</th>
+                      <th style={{ textAlign: 'right', padding: '0.75rem', fontWeight: '600' }}>5Y</th>
                       <th style={{ textAlign: 'right', padding: '0.75rem', fontWeight: '600' }}>Sharpe</th>
                       <th style={{ textAlign: 'right', padding: '0.75rem', fontWeight: '600' }}>Expense</th>
                       <th style={{ textAlign: 'center', padding: '0.75rem', fontWeight: '600' }}>Type</th>
@@ -828,7 +830,13 @@ const App = () => {
                             )}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                            {fund['YTD'] != null ? `${fund['YTD'].toFixed(2)}%` : 'N/A'}
+                          </td>
+                          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                             {fund['1 Year'] != null ? `${fund['1 Year'].toFixed(2)}%` : 'N/A'}
+                          </td>
+                          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                            {fund['5 Year'] != null ? `${fund['5 Year'].toFixed(2)}%` : 'N/A'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                             {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : 'N/A'}
@@ -1020,8 +1028,10 @@ const App = () => {
                     <th style={{ padding: '0.75rem', textAlign: 'left' }}>Symbol</th>
                     <th style={{ padding: '0.75rem', textAlign: 'left' }}>Name</th>
                     <th style={{ padding: '0.75rem', textAlign: 'center' }}>Score</th>
+                    <th style={{ padding: '0.75rem', textAlign: 'right' }}>YTD</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>3Y</th>
+                    <th style={{ padding: '0.75rem', textAlign: 'right' }}>5Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>Sharpe</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>Std Dev 3Y</th>
                     <th style={{ padding: '0.75rem', textAlign: 'right' }}>Expense</th>
@@ -1053,10 +1063,16 @@ const App = () => {
                         ) : '-'}
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                        {benchmarkData[selectedClass]['YTD']?.toFixed(2) ?? 'N/A'}%
+                      </td>
+                      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                         {benchmarkData[selectedClass]['1 Year']?.toFixed(2) ?? 'N/A'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                         {benchmarkData[selectedClass]['3 Year']?.toFixed(2) ?? 'N/A'}%
+                      </td>
+                      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                        {benchmarkData[selectedClass]['5 Year']?.toFixed(2) ?? 'N/A'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                         {benchmarkData[selectedClass]['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
@@ -1103,10 +1119,16 @@ const App = () => {
                           ) : '-'}
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                          {fund['YTD']?.toFixed(2) ?? 'N/A'}%
+                        </td>
+                        <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                           {fund['1 Year']?.toFixed(2) ?? 'N/A'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                           {fund['3 Year']?.toFixed(2) ?? 'N/A'}%
+                        </td>
+                        <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+                          {fund['5 Year']?.toFixed(2) ?? 'N/A'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
                           {fund['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}


### PR DESCRIPTION
## Summary
- show YTD and 5Y performance in fund tables
- include benchmark values for YTD and 5Y
- align new numeric columns to the right

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686593ad41b88329a0d6e66643d9471f