### PR TITLE
Fix expense ratio mapping

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -244,7 +244,9 @@ const App = () => {
             if (header.includes('Down Capture')) columnMap['Down Capture Ratio'] = index;
             
             // Other metrics
-            if (header.includes('Expense') && header.includes('Net')) columnMap['Net Expense Ratio'] = index;
+            if (header.includes('Expense') && (header.includes('Net') || header.includes('Ratio'))) {
+              columnMap['Net Expense Ratio'] = index;
+            }
             if (header.includes('Manager Tenure')) columnMap['Manager Tenure'] = index;
           }
         });


### PR DESCRIPTION
## Summary
- broaden mapping logic for Net Expense Ratio column

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6865c575cfc483299f26ceb62fc86d4e