### PR TITLE
Use dash for missing metrics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -834,25 +834,25 @@ const App = () => {
                             )}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['YTD'] != null ? `${fund['YTD'].toFixed(2)}%` : 'N/A'}
+                            {fund['YTD'] != null ? `${fund['YTD'].toFixed(2)}%` : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['1 Year'] != null ? `${fund['1 Year'].toFixed(2)}%` : 'N/A'}
+                            {fund['1 Year'] != null ? `${fund['1 Year'].toFixed(2)}%` : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['5 Year'] != null ? `${fund['5 Year'].toFixed(2)}%` : 'N/A'}
+                            {fund['5 Year'] != null ? `${fund['5 Year'].toFixed(2)}%` : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : 'N/A'}
+                            {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['StdDev3Y'] != null ? fund['StdDev3Y'].toFixed(2) : 'N/A'}
+                            {fund['StdDev3Y'] != null ? fund['StdDev3Y'].toFixed(2) : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['StdDev5Y'] != null ? fund['StdDev5Y'].toFixed(2) : 'N/A'}
+                            {fund['StdDev5Y'] != null ? fund['StdDev5Y'].toFixed(2) : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['Net Expense Ratio'] != null ? `${fund['Net Expense Ratio'].toFixed(2)}%` : 'N/A'}
+                            {fund['Net Expense Ratio'] != null ? `${fund['Net Expense Ratio'].toFixed(2)}%` : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'center' }}>
                             {fund.isBenchmark && (
@@ -1011,7 +1011,7 @@ const App = () => {
                     <div>
                       <div style={{ color: '#6b7280', fontSize: '0.875rem' }}>Benchmark Score</div>
                       <div style={{ fontSize: '1.25rem', fontWeight: 'bold' }}>
-                        {classSummaries[selectedClass].benchmarkScore || 'N/A'}
+                        {classSummaries[selectedClass].benchmarkScore || '-'}
                       </div>
                     </div>
                     <div>
@@ -1074,28 +1074,28 @@ const App = () => {
                         ) : '-'}
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['YTD']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['YTD']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['1 Year']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['1 Year']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['3 Year']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['3 Year']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['5 Year']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['5 Year']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
+                        {benchmarkData[selectedClass]['Sharpe Ratio']?.toFixed(2) ?? '-'}
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['StdDev3Y']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['StdDev3Y']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['StdDev5Y']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['StdDev5Y']?.toFixed(2) ?? '-'}%
                       </td>
                       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                        {benchmarkData[selectedClass]['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%
+                        {benchmarkData[selectedClass]['Net Expense Ratio']?.toFixed(2) ?? '-'}%
                       </td>
                     </tr>
                   )}
@@ -1133,28 +1133,28 @@ const App = () => {
                           ) : '-'}
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['YTD']?.toFixed(2) ?? 'N/A'}%
+                          {fund['YTD']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['1 Year']?.toFixed(2) ?? 'N/A'}%
+                          {fund['1 Year']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['3 Year']?.toFixed(2) ?? 'N/A'}%
+                          {fund['3 Year']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['5 Year']?.toFixed(2) ?? 'N/A'}%
+                          {fund['5 Year']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
+                          {fund['Sharpe Ratio']?.toFixed(2) ?? '-'}
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['StdDev3Y']?.toFixed(2) ?? 'N/A'}%
+                          {fund['StdDev3Y']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['StdDev5Y']?.toFixed(2) ?? 'N/A'}%
+                          {fund['StdDev5Y']?.toFixed(2) ?? '-'}%
                         </td>
                         <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                          {fund['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%
+                          {fund['Net Expense Ratio']?.toFixed(2) ?? '-'}%
                         </td>
                       </tr>
                     ))}
@@ -1251,15 +1251,15 @@ const App = () => {
                           }}>
                             <div>
                               <span style={{ color: '#6b7280' }}>1Y Return:</span>{' '}
-                              <strong>{fund['1 Year']?.toFixed(2) ?? 'N/A'}%</strong>
+                              <strong>{fund['1 Year']?.toFixed(2) ?? '-'}%</strong>
                             </div>
                             <div>
                               <span style={{ color: '#6b7280' }}>Sharpe:</span>{' '}
-                              <strong>{fund['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}</strong>
+                              <strong>{fund['Sharpe Ratio']?.toFixed(2) ?? '-'}</strong>
                             </div>
                             <div>
                               <span style={{ color: '#6b7280' }}>Expense:</span>{' '}
-                              <strong>{fund['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%</strong>
+                              <strong>{fund['Net Expense Ratio']?.toFixed(2) ?? '-'}%</strong>
                             </div>
                           </div>
                         </div>

--- a/src/components/Analytics/RiskReturnScatter.jsx
+++ b/src/components/Analytics/RiskReturnScatter.jsx
@@ -383,7 +383,7 @@ const RiskReturnScatter = ({ funds }) => {
             <div>Return: {hoveredFund.riskReturnMetrics.return.toFixed(2)}%</div>
             <div>Risk: {hoveredFund.riskReturnMetrics.risk.toFixed(2)}%</div>
             <div>Sharpe: {hoveredFund.riskReturnMetrics.sharpeRatio.toFixed(2)}</div>
-            <div>Score: {hoveredFund.scores?.final || 'N/A'}</div>
+            <div>Score: {hoveredFund.scores?.final || '-'}</div>
           </div>
         </div>
       )}

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -366,21 +366,21 @@ const AssetClassOverview = ({ funds, classSummaries, benchmarkData }) => {
                     <div>
                       <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>Average Sharpe Ratio</div>
                       <div style={{ fontWeight: '600' }}>
-                        {stats.avgSharpe != null ? stats.avgSharpe.toFixed(2) : 'N/A'}
+                        {stats.avgSharpe != null ? stats.avgSharpe.toFixed(2) : '-'}
                       </div>
                     </div>
                     
                     <div>
                       <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>Average Expense Ratio</div>
                       <div style={{ fontWeight: '600' }}>
-                        {stats.avgExpense != null ? `${stats.avgExpense.toFixed(2)}%` : 'N/A'}
+                        {stats.avgExpense != null ? `${stats.avgExpense.toFixed(2)}%` : '-'}
                       </div>
                     </div>
                     
                     <div>
                       <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>3-Year Return</div>
                       <div style={{ fontWeight: '600' }}>
-                        {stats.avgReturn3Y != null ? `${stats.avgReturn3Y.toFixed(1)}%` : 'N/A'}
+                        {stats.avgReturn3Y != null ? `${stats.avgReturn3Y.toFixed(1)}%` : '-'}
                       </div>
                     </div>
                     

--- a/src/components/Tags/TagManager.jsx
+++ b/src/components/Tags/TagManager.jsx
@@ -132,7 +132,7 @@ const TagManager = ({ funds, benchmarkData, onFilterChange }) => {
               {fund.Symbol} - {fund['Fund Name']}
             </div>
             <div style={{ fontSize: '0.75rem', color: '#6b7280', marginBottom: '0.5rem' }}>
-              {fund['Asset Class']} | Score: {fund.scores?.final || 'N/A'}
+              {fund['Asset Class']} | Score: {fund.scores?.final || '-'}
             </div>
             <div style={{ display: 'flex', flexWrap: 'wrap' }}>
               {tags.map((tag, i) => (


### PR DESCRIPTION
## Summary
- replace `N/A` display strings with `-`
- ensure hover details in scatter plot and tag manager use `-`
- update asset class overview metrics to show `-`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6865cab553e8832995f1646c089d5537