### PR TITLE
Fix scoring for asset classes with few funds

### DIFF
--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -217,7 +217,10 @@ const METRIC_WEIGHTS = {
       const value = fund.metrics?.[metric];
       const stats = statistics[metric];
       
-      if (value != null && stats && stats.stdDev > 0 && stats.count > 2) {
+      // Allow scoring when at least a benchmark and one fund are present
+      // (two values). Previously required >2 which skipped small asset
+      // classes entirely.
+      if (value != null && stats && stats.stdDev > 0 && stats.count >= 2) {
         const zScore = calculateZScore(value, stats.mean, stats.stdDev);
         const weightedZScore = zScore * weight;
         


### PR DESCRIPTION
## Summary
- score metrics when at least two funds (including a benchmark) exist in an asset class

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c5edca948329aa6497955f30c893