### PR TITLE
Update badge styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,23 +41,24 @@ import {
 const ScoreBadge = ({ score, size = 'normal' }) => {
   const color = getScoreColor(score);
   const label = getScoreLabel(score);
-  
+
   const sizeClasses = {
     small: 'text-xs px-1.5 py-0.5',
     normal: 'text-sm px-2 py-1',
     large: 'text-base px-3 py-1.5'
   };
-  
+
   return (
-    <span 
-      className={`inline-flex items-center rounded-full font-medium ${sizeClasses[size]}`}
-      style={{ 
-        backgroundColor: `${color}20`,
+    <span
+      className={`inline-flex items-center rounded-full font-semibold ${sizeClasses[size]}`}
+      style={{
+        backgroundColor: `${color}30`,
         color: color,
-        border: `1px solid ${color}50`
+        border: `1px solid ${color}`
       }}
+      title={label}
     >
-      {score} - {label}
+      {score}
     </span>
   );
 };

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -364,7 +364,8 @@ export function generateHTMLReport(data) {
       padding: 4px 12px;
       border-radius: 999px;
       font-weight: 600;
-      font-size: 0.9em;
+      font-size: 0.95em;
+      border: 1px solid currentColor;
     }
     .score-excellent { background: #d1fae5; color: #065f46; }
     .score-good { background: #fef3c7; color: #78350f; }
@@ -442,7 +443,7 @@ export function generateHTMLReport(data) {
             <small style="color: #666">${fund['Asset Class']}</small>
           </td>
           <td>
-            <span class="score-badge ${getScoreClass(fund.scores?.final || 0)}">
+            <span class="score-badge ${getScoreClass(fund.scores?.final || 0)}" title="${getScoreLabel(fund.scores?.final || 0)}">
               ${fund.scores?.final || 'N/A'}
             </span>
           </td>
@@ -515,7 +516,7 @@ export function generateHTMLReport(data) {
             <small>${fund['Fund Name']}</small>
           </td>
           <td>
-            <span class="score-badge ${getScoreClass(fund.scores?.final || 0)}">
+            <span class="score-badge ${getScoreClass(fund.scores?.final || 0)}" title="${getScoreLabel(fund.scores?.final || 0)}">
               ${fund.scores?.final || 'N/A'}
             </span>
           </td>


### PR DESCRIPTION
## Summary
- simplify ScoreBadge component styling
- add a tooltip label and remove text from score badges
- adjust exported badge styles

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6866ca92cf9c8329ac719eb9ec3452ab