### PR TITLE
Fix asset class PDF table columns

### DIFF
--- a/src/services/pdfReportService.js
+++ b/src/services/pdfReportService.js
@@ -234,6 +234,7 @@ function addAssetClassTable(doc, assetClass, funds, benchmark) {
     startY: startY + 10,
     head: [TABLE_COLUMNS.map(col => col.header)],
     body: tableData.map(row => TABLE_COLUMNS.map(col => row[col.dataKey] || '')),
+    columns: TABLE_COLUMNS,
     headStyles: {
       fillColor: REPORT_CONFIG.colors.headerBg,
       textColor: REPORT_CONFIG.colors.headerText,


### PR DESCRIPTION
## Summary
- include column metadata when generating PDF tables to ensure string dataKey values

## Testing
- `CI=true npm test --silent -- --passWithNoTests`
- Node sanity checks for `autoTable` dataKey types

------
https://chatgpt.com/codex/tasks/task_e_686c0d7ecd5c8329b4950f02db67fbf0