### PR TITLE
Fix rank column header styling

### DIFF
--- a/src/services/pdfReportService.js
+++ b/src/services/pdfReportService.js
@@ -279,7 +279,13 @@ function addAssetClassTable(doc, assetClass, funds, benchmark) {
     },
     didDrawCell: function(data) {
       // Custom rendering for rank cells with color coding
-      if (data.column.dataKey && data.column.dataKey.includes('Rank') && data.row.index < tableData.length - 1) {
+      // Apply only to body cells so header cells remain unstyled
+      if (
+        data.section === 'body' &&
+        data.column.dataKey &&
+        data.column.dataKey.includes('Rank') &&
+        data.row.index < tableData.length - 1
+      ) {
         const rankValue = parseInt(data.cell.text);
         if (!isNaN(rankValue)) {
           // Clear the default text


### PR DESCRIPTION
## Summary
- ensure rank cell color coding only applies to body rows in PDF report

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_686d2f9518408329b948fe09ceeac94f