### PR TITLE
Improve PDF pagination

### DIFF
--- a/src/services/pdfReportService.js
+++ b/src/services/pdfReportService.js
@@ -109,34 +109,29 @@ export function generateMonthlyReport(data) {
 
   // Add cover page
   addCoverPage(doc, metadata);
-  
+
+  // Start a new page for report tables
+  doc.addPage();
+
   // Group funds by asset class and filter out benchmarks from main list
   const fundsByClass = groupAndFilterFunds(funds, benchmarks);
-  
+
   // Add each asset class section
-  let currentPage = 2;
-  assetClassGroups.forEach((group, groupIndex) => {
-    group.classes.forEach((assetClass, classIndex) => {
+  assetClassGroups.forEach(group => {
+    group.classes.forEach(assetClass => {
       const classFunds = fundsByClass[assetClass] || [];
       const benchmark = benchmarks[assetClass];
-      
+
       // Skip empty asset classes
       if (classFunds.length === 0 && !benchmark) return;
-      
-      // Check if we need a new page
-      const currentY = doc.lastAutoTable?.finalY || REPORT_CONFIG.margins.top;
-      if (currentY > 420 || (groupIndex > 0 && classIndex === 0)) {
-        doc.addPage();
-        currentPage++;
-      }
-      
+
       // Add asset class table
       addAssetClassTable(doc, assetClass, classFunds, benchmark);
     });
   });
-  
+
   // Add page numbers
-  addPageNumbers(doc, currentPage);
+  addPageNumbers(doc, doc.getNumberOfPages());
   
   return doc;
 }
@@ -269,6 +264,7 @@ function addAssetClassTable(doc, assetClass, funds, benchmark) {
       fillColor: REPORT_CONFIG.colors.alternateRow
     },
     columnStyles: getColumnStyles(),
+    pageBreak: 'avoid',
     didParseCell: function(data) {
       // Highlight benchmark row
       if (benchmark && data.row.index === tableData.length - 1) {


### PR DESCRIPTION
## Summary
- paginate PDF after cover page
- let jsPDF auto handle group pagination and avoid table splits
- prevent table splitting with `pageBreak: 'avoid'`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d32d4ec808329950998103dbcfaf2