### PR TITLE
Fix benchmark detection in monthly report generation

### DIFF
--- a/src/components/Reports/MonthlyReportButton.jsx
+++ b/src/components/Reports/MonthlyReportButton.jsx
@@ -59,11 +59,14 @@ const MonthlyReportButton = ({
   // Extract benchmark data from the fund list
   const prepareBenchmarkData = (allFunds, benchmarkMappings) => {
     const prepared = {};
-    
+
+    const clean = (s) => s?.toUpperCase().trim();
+
     Object.entries(benchmarkMappings).forEach(([assetClass, benchmarkInfo]) => {
-      // Find the benchmark fund in the data
-      const benchmarkFund = allFunds.find(f => f.Symbol === benchmarkInfo.ticker);
-      
+      // Find the benchmark fund in the data using a cleaned ticker match
+      const ticker = clean(benchmarkInfo.ticker);
+      const benchmarkFund = allFunds.find(f => clean(f.Symbol) === ticker);
+
       if (benchmarkFund) {
         prepared[assetClass] = {
           ticker: benchmarkInfo.ticker,
@@ -72,7 +75,7 @@ const MonthlyReportButton = ({
         };
       }
     });
-    
+
     return prepared;
   };
 


### PR DESCRIPTION
## Summary
- more robust benchmark lookup when creating monthly PDF report

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d3fb6891083298958e6e7d8eaa709