### PR TITLE
Fix missing benchmark rows

### DIFF
--- a/src/components/Reports/MonthlyReportButton.jsx
+++ b/src/components/Reports/MonthlyReportButton.jsx
@@ -59,11 +59,19 @@ const MonthlyReportButton = ({
   // Extract benchmark data from the fund list
   const prepareBenchmarkData = (allFunds, benchmarkMappings) => {
     const prepared = {};
-    
+
+    // Helper to clean tickers for reliable matching
+    const clean = (s) => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+
     Object.entries(benchmarkMappings).forEach(([assetClass, benchmarkInfo]) => {
-      // Find the benchmark fund in the data
-      const benchmarkFund = allFunds.find(f => f.Symbol === benchmarkInfo.ticker);
-      
+      const target = clean(benchmarkInfo.ticker);
+
+      // Find the benchmark fund in the data using cleaned tickers
+      const benchmarkFund = allFunds.find(f => {
+        const symbol = f.Symbol || f['Symbol/CUSIP'];
+        return clean(symbol) === target;
+      });
+
       if (benchmarkFund) {
         prepared[assetClass] = {
           ticker: benchmarkInfo.ticker,
@@ -72,7 +80,7 @@ const MonthlyReportButton = ({
         };
       }
     });
-    
+
     return prepared;
   };
 


### PR DESCRIPTION
## Summary
- ensure benchmark lookup is case-insensitive and handles Symbol/CUSIP column

## Testing
- `CI=true npm test -- --passWithNoTests --watchAll=false`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_686d3fb6891083298958e6e7d8eaa709