### PR TITLE
Fix missing benchmark rows

### DIFF
--- a/src/components/Reports/MonthlyReportButton.jsx
+++ b/src/components/Reports/MonthlyReportButton.jsx
@@ -19,8 +19,9 @@ const MonthlyReportButton = ({
       const benchmarkData = prepareBenchmarkData(fundData, assetClassBenchmarks);
       
       // Filter out benchmarks from the main fund list for the report
-      const benchmarkTickers = new Set(Object.values(assetClassBenchmarks).map(b => b.ticker));
-      const nonBenchmarkFunds = fundData.filter(f => !benchmarkTickers.has(f.Symbol));
+      const cleanTicker = (s) => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+      const benchmarkTickers = new Set(Object.values(assetClassBenchmarks).map(b => cleanTicker(b.ticker)));
+      const nonBenchmarkFunds = fundData.filter(f => !benchmarkTickers.has(cleanTicker(f.cleanSymbol || f.Symbol || f['Symbol/CUSIP'])));
       
       // Prepare report data
       const reportData = {
@@ -59,11 +60,19 @@ const MonthlyReportButton = ({
   // Extract benchmark data from the fund list
   const prepareBenchmarkData = (allFunds, benchmarkMappings) => {
     const prepared = {};
-    
+
+    // Helper to clean tickers for reliable matching
+    const clean = (s) => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+
     Object.entries(benchmarkMappings).forEach(([assetClass, benchmarkInfo]) => {
-      // Find the benchmark fund in the data
-      const benchmarkFund = allFunds.find(f => f.Symbol === benchmarkInfo.ticker);
-      
+      const target = clean(benchmarkInfo.ticker);
+
+      // Find the benchmark fund in the data using cleaned tickers
+      const benchmarkFund = allFunds.find(f => {
+        const symbol = f.cleanSymbol || f.Symbol || f['Symbol/CUSIP'];
+        return clean(symbol) === target;
+      });
+
       if (benchmarkFund) {
         prepared[assetClass] = {
           ticker: benchmarkInfo.ticker,
@@ -72,7 +81,7 @@ const MonthlyReportButton = ({
         };
       }
     });
-    
+
     return prepared;
   };
 


### PR DESCRIPTION
## Summary
- ensure benchmark filtering uses cleaned tickers
- look up benchmark funds using `cleanSymbol` when available

## Testing
- `npm test -- --passWithNoTests --watchAll=false`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_686d3fb6891083298958e6e7d8eaa709