### PR TITLE
Fix rank columns in PDF reports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -262,8 +262,13 @@ const App = () => {
                     if (headerClean === 'Total Return - YTD (%)') {
                       columnMap['YTD'] = index;
                     }
-                    if (headerClean === 'Category Rank (%) Total Return – YTD' || 
-                        headerClean === 'Category Rank (%) Total Return - YTD') {
+                    if (
+                      headerClean === 'Category Rank (%) Total Return – YTD' ||
+                      headerClean === 'Category Rank (%) Total Return - YTD' ||
+                      (headerLower.includes('category rank') &&
+                        headerLower.includes('total return') &&
+                        headerLower.includes('ytd'))
+                    ) {
                       columnMap['YTD Rank'] = index;
                     }
                     
@@ -271,8 +276,15 @@ const App = () => {
                     if (headerClean === 'Total Return - 1 Year (%)') {
                       columnMap['1 Year'] = index;
                     }
-                    if (headerClean === 'Category Rank (%) Total Return – 1Y' || 
-                        headerClean === 'Category Rank (%) Total Return - 1Y') {
+                    if (
+                      headerClean === 'Category Rank (%) Total Return – 1Y' ||
+                      headerClean === 'Category Rank (%) Total Return - 1Y' ||
+                      (headerLower.includes('category rank') &&
+                        headerLower.includes('total return') &&
+                        (headerLower.includes('1y') || headerLower.includes('1 year')) &&
+                        !headerLower.includes('10y') &&
+                        !headerLower.includes('10 year'))
+                    ) {
                       columnMap['1Y Rank'] = index;
                     }
                     
@@ -280,8 +292,13 @@ const App = () => {
                     if (headerClean === 'Annualized Total Return - 3 Year (%)') {
                       columnMap['3 Year'] = index;
                     }
-                    if (headerClean === 'Category Rank (%) Ann. Total Return – 3Y' || 
-                        headerClean === 'Category Rank (%) Ann. Total Return - 3Y') {
+                    if (
+                      headerClean === 'Category Rank (%) Ann. Total Return – 3Y' ||
+                      headerClean === 'Category Rank (%) Ann. Total Return - 3Y' ||
+                      (headerLower.includes('category rank') &&
+                        headerLower.includes('total return') &&
+                        (headerLower.includes('3y') || headerLower.includes('3 year')))
+                    ) {
                       columnMap['3Y Rank'] = index;
                     }
                     
@@ -289,8 +306,13 @@ const App = () => {
                     if (headerClean === 'Annualized Total Return - 5 Year (%)') {
                       columnMap['5 Year'] = index;
                     }
-                    if (headerClean === 'Category Rank (%) Ann. Total Return – 5Y' || 
-                        headerClean === 'Category Rank (%) Ann. Total Return - 5Y') {
+                    if (
+                      headerClean === 'Category Rank (%) Ann. Total Return – 5Y' ||
+                      headerClean === 'Category Rank (%) Ann. Total Return - 5Y' ||
+                      (headerLower.includes('category rank') &&
+                        headerLower.includes('total return') &&
+                        (headerLower.includes('5y') || headerLower.includes('5 year')))
+                    ) {
                       columnMap['5Y Rank'] = index;
                     }
                     
@@ -298,8 +320,13 @@ const App = () => {
                     if (headerClean === 'Annualized Total Return - 10 Year (%)') {
                       columnMap['10 Year'] = index;
                     }
-                    if (headerClean === 'Category Rank (%) Ann. Total Return – 10Y' || 
-                        headerClean === 'Category Rank (%) Ann. Total Return - 10Y') {
+                    if (
+                      headerClean === 'Category Rank (%) Ann. Total Return – 10Y' ||
+                      headerClean === 'Category Rank (%) Ann. Total Return - 10Y' ||
+                      (headerLower.includes('category rank') &&
+                        headerLower.includes('total return') &&
+                        (headerLower.includes('10y') || headerLower.includes('10 year')))
+                    ) {
                       columnMap['10Y Rank'] = index;
                     }
                     

--- a/src/services/pdfReportService.js
+++ b/src/services/pdfReportService.js
@@ -391,13 +391,37 @@ function prepareRowData(fund) {
       10
     ) || 0,
     ytd: formatPercent(fund['YTD'] || fund['Total Return - YTD (%)']),
-    ytdRank: formatRank(fund['YTD Rank'] || fund['Category Rank (%) Total Return – YTD'] || fund['YTD Cat Rank']),
+    ytdRank: formatRank(
+      fund['YTD Rank'] ||
+      fund['Category Rank (%) Total Return – YTD'] ||
+      fund['Category Rank (%) Total Return - YTD'] ||
+      fund['Category Rank (%) Total Return  YTD'] ||
+      fund['YTD Cat Rank']
+    ),
     oneYear: formatPercent(fund['1 Year'] || fund['Total Return - 1 Year (%)']),
-    oneYearRank: formatRank(fund['1Y Rank'] || fund['Category Rank (%) Total Return – 1Y'] || fund['1Y Cat Rank']),
+    oneYearRank: formatRank(
+      fund['1Y Rank'] ||
+      fund['Category Rank (%) Total Return – 1Y'] ||
+      fund['Category Rank (%) Total Return - 1Y'] ||
+      fund['Category Rank (%) Total Return  1Y'] ||
+      fund['1Y Cat Rank']
+    ),
     threeYear: formatPercent(fund['3 Year'] || fund['Annualized Total Return - 3 Year (%)']),
-    threeYearRank: formatRank(fund['3Y Rank'] || fund['Category Rank (%) Ann. Total Return – 3Y'] || fund['3Y Cat Rank']),
+    threeYearRank: formatRank(
+      fund['3Y Rank'] ||
+      fund['Category Rank (%) Ann. Total Return – 3Y'] ||
+      fund['Category Rank (%) Ann. Total Return - 3Y'] ||
+      fund['Category Rank (%) Ann. Total Return  3Y'] ||
+      fund['3Y Cat Rank']
+    ),
     fiveYear: formatPercent(fund['5 Year'] || fund['Annualized Total Return - 5 Year (%)']),
-    fiveYearRank: formatRank(fund['5Y Rank'] || fund['Category Rank (%) Ann. Total Return – 5Y'] || fund['5Y Cat Rank']),
+    fiveYearRank: formatRank(
+      fund['5Y Rank'] ||
+      fund['Category Rank (%) Ann. Total Return – 5Y'] ||
+      fund['Category Rank (%) Ann. Total Return - 5Y'] ||
+      fund['Category Rank (%) Ann. Total Return  5Y'] ||
+      fund['5Y Cat Rank']
+    ),
     yield: formatPercent(fund['Yield'] || fund['SEC Yield'] || fund['SEC Yield (%)']),
     stdDev: formatNumber(fund['StdDev3Y'] || fund['Standard Deviation - 3 Year'] || fund['Standard Deviation'] || fund['3Y Std Dev']),
     expense: formatPercent(fund['Net Expense Ratio'] || fund['Net Exp Ratio (%)'] || fund['Expense Ratio']),


### PR DESCRIPTION
## Summary
- robust header matching for rank columns when parsing CSVs
- support alternate rank column names when generating PDF reports

## Testing
- `npm test -- --passWithNoTests --silent`

------
https://chatgpt.com/codex/tasks/task_e_686eda51c94c83299ad2d0b0ae48d4df