### PR TITLE
Add combined snapshot comparison

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,10 +19,13 @@ import {
 } from './services/scoring';
 import {
   saveSnapshot,
-  compareSnapshots as compareSnapshotsAPI,
   deleteSnapshot
 } from './services/dataStore';
-import { getAllCombinedSnapshots, getDataSummary } from './services/enhancedDataStore';
+import {
+  getAllCombinedSnapshots,
+  getDataSummary,
+  compareCombinedSnapshots as compareSnapshotsAPI
+} from './services/enhancedDataStore';
 import fundRegistry from './services/fundRegistry';
 import PerformanceHeatmap from './components/Dashboard/PerformanceHeatmap';
 import TopBottomPerformers from './components/Dashboard/TopBottomPerformers';


### PR DESCRIPTION
## Summary
- add `compareCombinedSnapshots` to handle comparisons that include historical data
- use the new utility in `App.jsx`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687130c27a608329a2fb8d38ef2f8dc8