### PR TITLE
Add explicit .js extensions to relative imports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,11 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { RefreshCw, Settings, Trash2, LayoutGrid, AlertCircle, TrendingUp, Award, Clock, Database, Calendar, Download, BarChart3, Activity, Info } from 'lucide-react';
 import * as XLSX from 'xlsx';
-import FundAdmin from './components/Admin/FundAdmin';
+import FundAdmin from './components/Admin/FundAdmin.jsx';
 import {
   recommendedFunds as defaultRecommendedFunds,
   assetClassBenchmarks as defaultBenchmarks
-} from './data/config';
+} from './data/config.js';
 import { 
   calculateScores, 
   generateClassSummary, 
@@ -16,40 +16,40 @@ import {
   METRICS_CONFIG,
   METRIC_ORDER,
   loadMetricWeights
-} from './services/scoring';
+} from './services/scoring.js';
 import {
   saveSnapshot,
   deleteSnapshot
-} from './services/dataStore';
+} from './services/dataStore.js';
 import {
   getAllCombinedSnapshots,
   getDataSummary,
   compareCombinedSnapshots as compareSnapshotsAPI
-} from './services/enhancedDataStore';
-import fundRegistry from './services/fundRegistry';
-import PerformanceHeatmap from './components/Dashboard/PerformanceHeatmap';
-import TopBottomPerformers from './components/Dashboard/TopBottomPerformers';
-import AssetClassOverview from './components/Dashboard/AssetClassOverview';
-import FundTimeline from './components/Trends/FundTimeline';
-import TagManager from './components/Tags/TagManager';
-import CorrelationMatrix from './components/Analytics/CorrelationMatrix';
-import RiskReturnScatter from './components/Analytics/RiskReturnScatter';
-import FundDetailsModal from './components/FundDetailsModal';
-import MonthlyReportButton from './components/Reports/MonthlyReportButton';
+} from './services/enhancedDataStore.js';
+import fundRegistry from './services/fundRegistry.js';
+import PerformanceHeatmap from './components/Dashboard/PerformanceHeatmap.jsx';
+import TopBottomPerformers from './components/Dashboard/TopBottomPerformers.jsx';
+import AssetClassOverview from './components/Dashboard/AssetClassOverview.jsx';
+import FundTimeline from './components/Trends/FundTimeline.jsx';
+import TagManager from './components/Tags/TagManager.jsx';
+import CorrelationMatrix from './components/Analytics/CorrelationMatrix.jsx';
+import RiskReturnScatter from './components/Analytics/RiskReturnScatter.jsx';
+import FundDetailsModal from './components/FundDetailsModal.jsx';
+import MonthlyReportButton from './components/Reports/MonthlyReportButton.jsx';
 import { 
   exportToExcel, 
   generateHTMLReport, 
   exportToCSV, 
   generateExecutiveSummary,
   downloadFile 
-} from './services/exportService';
+} from './services/exportService.js';
 import {
   calculateDiversification,
   identifyOutliers,
   performAttribution
-} from './services/analytics';
-import { processRawFunds } from './services/fundProcessor';
-import assetClassGroups from './data/assetClassGroups';
+} from './services/analytics.js';
+import { processRawFunds } from './services/fundProcessor.js';
+import assetClassGroups from './data/assetClassGroups.js';
 
 // Score badge component for visual display
 export const ScoreBadge = ({ score, size = 'normal' }) => {

--- a/src/components/Admin/FundAdmin.jsx
+++ b/src/components/Admin/FundAdmin.jsx
@@ -5,15 +5,15 @@ import {
   Filter, RefreshCw, Save, X, Check, AlertCircle, Clock,
   GitBranch, Archive, Eye, EyeOff
 } from 'lucide-react';
-import fundRegistry from '../../services/fundRegistry';
-import { migrateFundRegistry, isMigrationNeeded } from '../../utils/migrateFundRegistry';
+import fundRegistry from '../../services/fundRegistry.js';
+import { migrateFundRegistry, isMigrationNeeded } from '../../utils/migrateFundRegistry.js';
 import {
   METRIC_ORDER,
   METRICS_CONFIG,
   getMetricWeights,
   setMetricWeights,
   DEFAULT_WEIGHTS
-} from '../../services/scoring';
+} from '../../services/scoring.js';
 
 const FundAdmin = () => {
   // State management

--- a/src/components/Analytics/CorrelationMatrix.jsx
+++ b/src/components/Analytics/CorrelationMatrix.jsx
@@ -1,7 +1,7 @@
 // src/components/Analytics/CorrelationMatrix.jsx
 import React, { useState, useMemo } from 'react';
 import { Activity, Info, Filter } from 'lucide-react';
-import { calculateCorrelationMatrix } from '../../services/analytics';
+import { calculateCorrelationMatrix } from '../../services/analytics.js';
 
 /**
  * Correlation Matrix Component

--- a/src/components/Analytics/RiskReturnScatter.jsx
+++ b/src/components/Analytics/RiskReturnScatter.jsx
@@ -5,7 +5,7 @@ import {
   calculateRiskReturnMetrics, 
   findEfficientFrontier,
   calculatePortfolioStatistics 
-} from '../../services/analytics';
+} from '../../services/analytics.js';
 
 /**
  * Risk-Return Scatter Plot Component

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -1,7 +1,7 @@
 // src/components/Dashboard/AssetClassOverview.jsx
 import React, { useState, useMemo } from 'react';
 import { BarChart3, TrendingUp, TrendingDown, Activity, DollarSign } from 'lucide-react';
-import { getScoreColor, generateClassSummary } from '../../services/scoring';
+import { getScoreColor, generateClassSummary } from '../../services/scoring.js';
 
 /**
  * Asset Class Overview Component

--- a/src/components/Dashboard/PerformanceHeatmap.jsx
+++ b/src/components/Dashboard/PerformanceHeatmap.jsx
@@ -1,7 +1,7 @@
 // src/components/Dashboard/PerformanceHeatmap.jsx
 import React, { useState, useMemo } from 'react';
 import { Info } from 'lucide-react';
-import { getScoreColor } from '../../services/scoring';
+import { getScoreColor } from '../../services/scoring.js';
 
 /**
  * Performance Heatmap Component

--- a/src/components/Dashboard/TopBottomPerformers.jsx
+++ b/src/components/Dashboard/TopBottomPerformers.jsx
@@ -1,7 +1,7 @@
 // src/components/Dashboard/TopBottomPerformers.jsx
 import React, { useState, useMemo } from 'react';
 import { TrendingUp, TrendingDown, Award, AlertTriangle } from 'lucide-react';
-import { getScoreColor, getScoreLabel } from '../../services/scoring';
+import { getScoreColor, getScoreLabel } from '../../services/scoring.js';
 
 /**
  * Top and Bottom Performers Component

--- a/src/components/FundDetailsModal.jsx
+++ b/src/components/FundDetailsModal.jsx
@@ -1,7 +1,7 @@
 // src/components/FundDetailsModal.jsx
 import React from 'react';
-import { formatPercent, formatNumber, getMetricDisplayName } from '../utils/dataFormatting';
-import { ScoreBadge } from '../App';
+import { formatPercent, formatNumber, getMetricDisplayName } from '../utils/dataFormatting.js';
+import { ScoreBadge } from '../App.jsx';
 
 const FundDetailsModal = ({ fund, onClose }) => {
   if (!fund) return null;

--- a/src/components/Reports/MonthlyReportButton.jsx
+++ b/src/components/Reports/MonthlyReportButton.jsx
@@ -1,8 +1,8 @@
 // src/components/Reports/MonthlyReportButton.jsx
 import React, { useState } from 'react';
 import { FileText, Loader } from 'lucide-react';
-import { generateMonthlyReport } from '../../services/pdfReportService';
-import assetClassGroups from '../../data/assetClassGroups';
+import { generateMonthlyReport } from '../../services/pdfReportService.js';
+import assetClassGroups from '../../data/assetClassGroups.js';
 
 const MonthlyReportButton = ({ 
   fundData, 

--- a/src/components/Tags/TagManager.jsx
+++ b/src/components/Tags/TagManager.jsx
@@ -9,7 +9,7 @@ import {
   TAG_CATEGORIES,
   DEFAULT_TAG_RULES,
   TAG_CATEGORY_MAP
-} from '../../services/tagEngine';
+} from '../../services/tagEngine.js';
 
 /**
  * Tag Manager Component

--- a/src/components/Trends/FundTimeline.jsx
+++ b/src/components/Trends/FundTimeline.jsx
@@ -1,7 +1,7 @@
 // src/components/Trends/FundTimeline.jsx
 import React, { useState, useMemo } from 'react';
 import { TrendingUp, TrendingDown, Calendar, Info, LineChart } from 'lucide-react';
-import { getScoreColor } from '../../services/scoring';
+import { getScoreColor } from '../../services/scoring.js';
 
 /**
  * Fund Timeline Component

--- a/src/utils/dataFormatting.js
+++ b/src/utils/dataFormatting.js
@@ -1,5 +1,5 @@
 // src/utils/dataFormatting.js
-import { getScoreLabel } from '../services/scoring';
+import { getScoreLabel } from '../services/scoring.js';
 
 /**
  * Utility functions for consistent data formatting and display

--- a/src/utils/migrateFundRegistry.js
+++ b/src/utils/migrateFundRegistry.js
@@ -1,7 +1,7 @@
 // src/utils/migrateFundRegistry.js
 
-import fundRegistry from '../services/fundRegistry';
-import { recommendedFunds, assetClassBenchmarks } from '../data/config';
+import fundRegistry from '../services/fundRegistry.js';
+import { recommendedFunds, assetClassBenchmarks } from '../data/config.js';
 
 /**
  * Migration utility to import existing config into new fund registry


### PR DESCRIPTION
## Summary
- add `.js` or `.jsx` extensions to relative imports for ESM compatibility

## Testing
- `npm test --silent -- --passWithNoTests`
- `npm run build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68892da7a5a8832997ca97f6c584aac9