### PR TITLE
feat: add global scoring option

### DIFF
--- a/docs/PHASE1_SERVER_SCORING.md
+++ b/docs/PHASE1_SERVER_SCORING.md
@@ -12,7 +12,7 @@ Phase 1 implements server-side scoring migration that exactly replicates the cli
 
 ### Core Components
 
-1. **`calculate_scores_as_of(date, asset_class_id)`** - Main scoring RPC
+1. **`calculate_scores_as_of(date, asset_class_id, global)`** - Main scoring RPC
 2. **Mathematical Helper Functions** - Exact replicas of client-side math.js
 3. **Updated `get_asset_class_table()`** - Integrated scoring support
 4. **Feature Flag Integration** - `REACT_APP_DB_SCORES` for gradual rollout
@@ -133,12 +133,13 @@ The server-side scoring is automatically integrated when the feature flag is ena
 
 ### API Endpoints
 
-#### `calculate_scores_as_of(date, asset_class_id)`
+#### `calculate_scores_as_of(date, asset_class_id, global)`
 
-Returns scored funds for a specific date and asset class:
+Returns scored funds for a specific date and asset class. Pass `true` for `global` to compute statistics across all asset classes:
 
 ```sql
-SELECT * FROM calculate_scores_as_of('2025-07-31', 'asset-class-uuid');
+SELECT * FROM calculate_scores_as_of('2025-07-31', 'asset-class-uuid', false);
+SELECT * FROM calculate_scores_as_of('2025-07-31', NULL, true); -- Global scoring
 ```
 
 **Returns:**
@@ -191,7 +192,7 @@ If the rollback script fails, manual intervention may be required:
 
 ```sql
 -- Drop all server-side scoring functions
-DROP FUNCTION IF EXISTS calculate_scores_as_of(date, uuid);
+DROP FUNCTION IF EXISTS calculate_scores_as_of(date, uuid, boolean);
 DROP FUNCTION IF EXISTS _calculate_mean(numeric[]);
 -- ... (drop all helper functions)
 

--- a/docs/PHASE1_TESTING_GUIDE.md
+++ b/docs/PHASE1_TESTING_GUIDE.md
@@ -78,9 +78,9 @@ node scripts/testServerScoringIntegration.js
 #### 1.2 Test Database Functions Directly
 ```sql
 -- Test server-side scoring RPC
-SELECT ticker, score_final, percentile 
-FROM calculate_scores_as_of('2025-07-31', NULL) 
-WHERE NOT is_benchmark 
+SELECT ticker, score_final, percentile
+FROM calculate_scores_as_of('2025-07-31', NULL, true)
+WHERE NOT is_benchmark
 LIMIT 5;
 
 -- Test updated asset class table
@@ -260,7 +260,7 @@ psql -h your-supabase-host -U postgres -d postgres -f supabase/migrations/202508
 ```bash
 # Error: permission denied for function
 # Solution: Check function grants
-psql -h your-supabase-host -U postgres -d postgres -c "GRANT EXECUTE ON FUNCTION calculate_scores_as_of(date, uuid) TO anon, authenticated, service_role;"
+psql -h your-supabase-host -U postgres -d postgres -c "GRANT EXECUTE ON FUNCTION calculate_scores_as_of(date, uuid, boolean) TO anon, authenticated, service_role;"
 ```
 
 #### 3. Feature Flag Not Working
@@ -281,7 +281,7 @@ npm start
 node scripts/benchmarkServerScoring.js
 
 # Verify RPC response times
-psql -h your-supabase-host -U postgres -d postgres -c "EXPLAIN ANALYZE SELECT * FROM calculate_scores_as_of('2025-07-31', NULL);"
+psql -h your-supabase-host -U postgres -d postgres -c "EXPLAIN ANALYZE SELECT * FROM calculate_scores_as_of('2025-07-31', NULL, true);"
 ```
 
 ### Debug Mode

--- a/docs/Status/STATUS.md
+++ b/docs/Status/STATUS.md
@@ -24,7 +24,7 @@
 ## Phase 1 Architecture
 
 ### Server-side Scoring Components
-- **`calculate_scores_as_of(date, asset_class_id)`** - Main scoring RPC
+- **`calculate_scores_as_of(date, asset_class_id, global)`** - Main scoring RPC
 - **Mathematical Functions** - Exact replicas of client-side math.js functions
 - **Scoring Logic** - Complete implementation of scoring.js algorithm
 - **Helper Functions** - Winsorization, robust scaling, tiny class fallbacks
@@ -78,7 +78,7 @@
 - **Recommended Funds:** 20 (first 20 funds marked)
 
 ### New RPCs Added
-- ✅ `calculate_scores_as_of(date, asset_class_id)` - Server-side scoring
+- ✅ `calculate_scores_as_of(date, asset_class_id, global)` - Server-side scoring
 - ✅ Updated `get_asset_class_table()` - Integrated scoring support
 
 ### Available Scripts

--- a/supabase/migrations/20250816_server_scoring.sql
+++ b/supabase/migrations/20250816_server_scoring.sql
@@ -558,7 +558,8 @@ $$;
 -- Main scoring function that exactly replicates client-side scoring.js
 CREATE OR REPLACE FUNCTION public.calculate_scores_as_of(
   p_date date,
-  p_asset_class_id uuid DEFAULT NULL
+  p_asset_class_id uuid DEFAULT NULL,
+  p_global boolean DEFAULT false
 )
 RETURNS TABLE(
   asset_class_id uuid,
@@ -624,11 +625,23 @@ DECLARE
   raw_scores numeric[];
   anchors jsonb;
 BEGIN
-  -- Get funds for the specified date and asset class
-  SELECT array_agg(f.*) INTO asset_class_funds
-  FROM public.get_funds_as_of(p_date) f
-  WHERE (p_asset_class_id IS NULL OR f.asset_class_id = p_asset_class_id)
-    AND f.asset_class_id IS NOT NULL;
+  IF p_global THEN
+    -- Get funds for the specified date across all asset classes
+    SELECT array_agg(f.*) INTO asset_class_funds
+    FROM public.get_funds_as_of(p_date) f
+    WHERE f.asset_class_id IS NOT NULL;
+  ELSE
+    -- Require asset class id for non-global scoring
+    IF p_asset_class_id IS NULL THEN
+      RAISE EXCEPTION 'asset_class_id required when p_global is false';
+    END IF;
+
+    -- Get funds for the specified date and asset class
+    SELECT array_agg(f.*) INTO asset_class_funds
+    FROM public.get_funds_as_of(p_date) f
+    WHERE f.asset_class_id = p_asset_class_id
+      AND f.asset_class_id IS NOT NULL;
+  END IF;
   
   IF asset_class_funds IS NULL OR array_length(asset_class_funds, 1) < 2 THEN
     -- Return default scores for insufficient funds
@@ -719,5 +732,5 @@ END;
 $$;
 
 -- Grant execute permissions
-GRANT EXECUTE ON FUNCTION public.calculate_scores_as_of(date, uuid) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.calculate_scores_as_of(date, uuid, boolean) TO anon, authenticated, service_role;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role; 


### PR DESCRIPTION
## Summary
- extend calculate_scores_as_of RPC with `p_global` flag for cross-asset scoring
- allow metric statistics functions to operate across all asset classes when global mode is enabled
- document new parameter and update grants

## Testing
- `npm test -- --watchAll=false` *(fails: 11 failed, 54 passed, 65 total)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e4b26c48329ae3140a305cc83ea