### PR TITLE
Use global scoring for fund list

### DIFF
--- a/src/services/fundService.js
+++ b/src/services/fundService.js
@@ -87,10 +87,10 @@ class FundService {
       const asOf = asOfDate ? new Date(asOfDate + 'T00:00:00Z') : null;
       const dateOnly = asOf ? asOf.toISOString().slice(0,10) : null;
       
-      // Get server-side scored funds
+      // Get server-side scored funds using global scoring
       const { data: scoredFunds, error: scoringError } = await supabase.rpc('calculate_scores_as_of', {
         p_date: dateOnly,
-        p_asset_class_id: null
+        p_global: true
       });
       
       if (scoringError) {


### PR DESCRIPTION
## Summary
- use new `p_global` flag in `calculate_scores_as_of` RPC
- remove unused asset class parameter

## Testing
- `npm test --silent -- --watchAll=false` *(fails: 2 test suites, 9 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae10c05fb48329a7bfb455ff002b84