### PR TITLE
Add diagnostic logging for asset class table

### DIFF
--- a/src/components/Dashboard/AssetClassTable.jsx
+++ b/src/components/Dashboard/AssetClassTable.jsx
@@ -62,6 +62,7 @@ const AssetClassTable = ({
 
       // Handle case where asset class ID is missing (legacy data)
       if (!assetClassId) {
+        console.warn('AssetClassTable: missing assetClassId', { assetClassName });
         setLoading(false);
         setError(`Asset class "${assetClassName}" is not configured in the database yet. Please import data using the Admin tab to set up this asset class.`);
         return;
@@ -71,28 +72,43 @@ const AssetClassTable = ({
       setError(null);
 
       try {
+        console.log('AssetClassTable: requesting table data', {
+          asOfMonth,
+          assetClassId,
+          includeBenchmark: true
+        });
+
         const tableData = await fundService.getAssetClassTable(
-          asOfMonth, 
-          assetClassId, 
+          asOfMonth,
+          assetClassId,
           true // include benchmark
         );
-        
+
+        console.log('AssetClassTable: raw data received', tableData);
+        console.log('AssetClassTable: raw row count', tableData ? tableData.length : 0);
+
         // Clean corrupted ticker data by removing appended labels
         const cleanedData = (tableData || []).map(row => {
           const originalTicker = row.ticker;
           const cleanedTicker = cleanTicker(row.ticker);
-          
-          return {
+
+          const transformedRow = {
             ...row,
             ticker: cleanedTicker,
             is_recommended: row.is_recommended || isRecommendedTicker(row.ticker),
             isBenchmark: row.is_benchmark || isBenchmarkTicker(row.ticker)
           };
+
+          console.log('AssetClassTable: transformed row', { original: row, transformed: transformedRow });
+          return transformedRow;
         });
-        
+
+        console.log('AssetClassTable: cleaned data', cleanedData);
+        console.log('AssetClassTable: cleaned row count', cleanedData.length);
+
         setData(cleanedData);
       } catch (err) {
-        console.error('Error loading asset class table:', err);
+        console.error('AssetClassTable: error loading asset class table', err);
         setError('Failed to load asset class data');
       } finally {
         setLoading(false);
@@ -195,8 +211,12 @@ const AssetClassTable = ({
 
   // Sort data
   const sortedData = useMemo(() => {
-    if (!data.length) return [];
-    
+    if (!data.length) {
+      console.log('AssetClassTable: no data available for sorting');
+      return [];
+    }
+
+    console.log('AssetClassTable: sorting data', { sortConfig, rowCount: data.length, data });
     const sorted = [...data].sort((a, b) => {
       let aValue = a[sortConfig.key];
       let bValue = b[sortConfig.key];
@@ -222,12 +242,14 @@ const AssetClassTable = ({
     
     // Always keep benchmark at bottom
     const benchmark = sorted.find(row => row.isBenchmark);
+    let finalSorted = sorted;
     if (benchmark) {
       const nonBenchmark = sorted.filter(row => !row.isBenchmark);
-      return [...nonBenchmark, benchmark];
+      finalSorted = [...nonBenchmark, benchmark];
     }
-    
-    return sorted;
+
+    console.log('AssetClassTable: sorted data result', finalSorted);
+    return finalSorted;
   }, [data, sortConfig]);
 
   // Helper function to get the correct field value with fallbacks
@@ -282,6 +304,11 @@ const AssetClassTable = ({
 
   const nonBenchmarkCount = data.filter(r => !r.isBenchmark).length;
   const benchmarkCount = data.filter(r => r.isBenchmark).length;
+  console.log('AssetClassTable: final data counts', {
+    total: data.length,
+    nonBenchmark: nonBenchmarkCount,
+    benchmark: benchmarkCount
+  });
 
   return (
     <div className="asset-class-table space-y-6">
@@ -493,75 +520,84 @@ const AssetClassTable = ({
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-100">
-              {sortedData.map((row, index) => {
-                const isRecommended = row.is_recommended;
-                const isBenchmark = row.isBenchmark;
-                
-                return (
-                  <tr 
-                    key={row.ticker || index}
-                    className={`
+              {(() => {
+                console.log('AssetClassTable: rendering table rows', sortedData.length);
+                return sortedData.map((row, index) => {
+                  try {
+                    console.log('AssetClassTable: rendering row', index, row);
+                    const isRecommended = row.is_recommended;
+                    const isBenchmark = row.isBenchmark;
+
+                    return (
+                      <tr
+                        key={row.ticker || index}
+                        className={`
                       table-row transition-all duration-200 hover:bg-gray-50
                       ${isBenchmark ? 'benchmark-row' : ''}
                       ${isRecommended ? 'recommended-row' : ''}
                     `}
-                  >
-                    {/* Fund Column */}
-                    <td className="table-cell px-6 py-4">
-                      <div className="fund-info-container">
-                        {/* Status Indicator Container - Fixed width */}
-                        <div className="status-indicator-container">
-                          {isRecommended && (
-                            <div className="status-dot recommended" title="Recommended Fund" />
-                          )}
-                          {isBenchmark && (
-                            <div className="status-dot benchmark" title="Benchmark Fund" />
-                          )}
-                          {!isRecommended && !isBenchmark && (
-                            <div className="status-dot regular" title="Regular Fund" />
-                          )}
-                        </div>
-                        
-                        {/* Fund Info Container */}
-                        <div className="fund-text-container">
-                          <div className="fund-ticker">
-                            {row.ticker}
+                      >
+                        {/* Fund Column */}
+                        <td className="table-cell px-6 py-4">
+                          <div className="fund-info-container">
+                            {/* Status Indicator Container - Fixed width */}
+                            <div className="status-indicator-container">
+                              {isRecommended && (
+                                <div className="status-dot recommended" title="Recommended Fund" />
+                              )}
+                              {isBenchmark && (
+                                <div className="status-dot benchmark" title="Benchmark Fund" />
+                              )}
+                              {!isRecommended && !isBenchmark && (
+                                <div className="status-dot regular" title="Regular Fund" />
+                              )}
+                            </div>
+
+                            {/* Fund Info Container */}
+                            <div className="fund-text-container">
+                              <div className="fund-ticker">
+                                {row.ticker}
+                              </div>
+                              <div className="fund-name">
+                                {row.name}
+                              </div>
+                            </div>
                           </div>
-                          <div className="fund-name">
-                            {row.name}
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                    
-                    {/* Score Column */}
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderScoreBadge(getFieldValue(row, 'score_final', ['score', 'final_score']))}
-                    </td>
-                    
-                    {/* Return Columns */}
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderReturn(getFieldValue(row, 'ytd_return', ['ytd', 'Total Return - YTD (%)']), 'YTD')}
-                    </td>
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderReturn(getFieldValue(row, 'one_year_return', ['1 Year', 'Total Return - 1 Year (%)']), '1Y')}
-                    </td>
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderReturn(getFieldValue(row, 'three_year_return', ['3 Year', 'Annualized Total Return - 3 Year (%)']), '3Y')}
-                    </td>
-                    
-                    {/* Expense Ratio */}
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderExpenseRatio(getFieldValue(row, 'expense_ratio', ['Net Exp Ratio (%)']))}
-                    </td>
-                    
-                    {/* Sharpe Ratio */}
-                    <td className="table-cell px-6 py-4 text-center">
-                      {renderSharpeRatio(getFieldValue(row, 'sharpe_ratio', ['Sharpe Ratio - 3 Year', 'Sharpe Ratio']))}
-                    </td>
-                  </tr>
-                );
-              })}
+                        </td>
+
+                        {/* Score Column */}
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderScoreBadge(getFieldValue(row, 'score_final', ['score', 'final_score']))}
+                        </td>
+
+                        {/* Return Columns */}
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderReturn(getFieldValue(row, 'ytd_return', ['ytd', 'Total Return - YTD (%)']), 'YTD')}
+                        </td>
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderReturn(getFieldValue(row, 'one_year_return', ['1 Year', 'Total Return - 1 Year (%)']), '1Y')}
+                        </td>
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderReturn(getFieldValue(row, 'three_year_return', ['3 Year', 'Annualized Total Return - 3 Year (%)']), '3Y')}
+                        </td>
+
+                        {/* Expense Ratio */}
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderExpenseRatio(getFieldValue(row, 'expense_ratio', ['Net Exp Ratio (%)']))}
+                        </td>
+
+                        {/* Sharpe Ratio */}
+                        <td className="table-cell px-6 py-4 text-center">
+                          {renderSharpeRatio(getFieldValue(row, 'sharpe_ratio', ['Sharpe Ratio - 3 Year', 'Sharpe Ratio']))}
+                        </td>
+                      </tr>
+                    );
+                  } catch (renderError) {
+                    console.error('AssetClassTable: error rendering row', index, renderError, row);
+                    return null;
+                  }
+                });
+              })()}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- log raw service data, transformations, and rendering details in AssetClassTable
- add extensive instrumentation in fundService.getAssetClassTable and server-scoring path

## Testing
- `npm test -- --watchAll=false` *(fails: 11 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af02023d5083299719b04f981ca51d