### PR TITLE
fix: namespace asset class table row styles

### DIFF
--- a/src/components/Dashboard/AssetClassTable.css
+++ b/src/components/Dashboard/AssetClassTable.css
@@ -421,18 +421,18 @@
 }
 
 /* Subtle hover effects */
-.asset-class-table .table-row {
+.asset-class-table .asset-table-row {
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
 }
 
-.asset-class-table .table-row:hover {
+.asset-class-table .asset-table-row:hover {
   background-color: #f9fafb;
   transform: translateY(-1px);
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
-.asset-class-table .table-row:not(.benchmark-row):not(.recommended-row):hover {
+.asset-class-table .asset-table-row:not(.benchmark-row):not(.recommended-row):hover {
   background-color: #f9fafb;
 }
 
@@ -520,7 +520,7 @@
 }
 
 /* Modern table cells - Enhanced for consistent heights and professional spacing */
-.asset-class-table .table-cell {
+.asset-class-table .asset-table-cell {
   padding: 22px 24px;
   vertical-align: middle;
   border-bottom: 1px solid #f3f4f6;
@@ -529,7 +529,7 @@
   transition: background-color 0.2s ease, transform 0.1s ease;
 }
 
-.asset-class-table .table-cell:hover {
+.asset-class-table .asset-table-cell:hover {
   background-color: rgba(59, 130, 246, 0.02);
 }
 
@@ -744,34 +744,34 @@
 }
 
 /* Enhanced benchmark row styling with subtle top border */
-.asset-class-table .table-row.benchmark-row {
+.asset-class-table .asset-table-row.benchmark-row {
   background-color: rgba(245, 158, 11, 0.08);
   position: relative;
   border-top: 1px solid rgba(245, 158, 11, 0.3);
   box-shadow: 0 -1px 0 rgba(245, 158, 11, 0.1);
 }
 
-.asset-class-table .table-row.benchmark-row:hover {
+.asset-class-table .asset-table-row.benchmark-row:hover {
   background-color: rgba(245, 158, 11, 0.12);
 }
 
 /* Enhanced recommended fund styling */
-.asset-class-table .table-row.recommended-row {
+.asset-class-table .asset-table-row.recommended-row {
   background-color: rgba(16, 185, 129, 0.06);
   position: relative;
 }
 
-.asset-class-table .table-row.recommended-row:hover {
+.asset-class-table .asset-table-row.recommended-row:hover {
   background-color: rgba(16, 185, 129, 0.08);
 }
 
 /* First cell is the positioning context for the stripe */
-.asset-class-table .table-row .table-cell:first-child {
+.asset-class-table .asset-table-row .asset-table-cell:first-child {
   position: relative;
 }
 
 /* Recommended stripe */
-.asset-class-table .table-row.recommended-row .table-cell:first-child::before {
+.asset-class-table .asset-table-row.recommended-row .asset-table-cell:first-child::before {
   content: '';
   position: absolute;
   left: 0; top: 0; bottom: 0;
@@ -780,7 +780,7 @@
 }
 
 /* Benchmark stripe */
-.asset-class-table .table-row.benchmark-row .table-cell:first-child::before {
+.asset-class-table .asset-table-row.benchmark-row .asset-table-cell:first-child::before {
   content: '';
   position: absolute;
   left: 0; top: 0; bottom: 0;
@@ -789,20 +789,20 @@
 }
 
 /* Enhanced benchmark row data styling - bold font weight for all values */
-.asset-class-table .table-row.benchmark-row .table-cell {
+.asset-class-table .asset-table-row.benchmark-row .asset-table-cell {
   font-weight: 600;
 }
 
-.asset-class-table .table-row.benchmark-row .fund-ticker {
+.asset-class-table .asset-table-row.benchmark-row .fund-ticker {
   font-weight: 800;
 }
 
-.asset-class-table .table-row.benchmark-row .fund-name {
+.asset-class-table .asset-table-row.benchmark-row .fund-name {
   font-weight: 500;
 }
 
 /* Bold numeric values in benchmark row */
-.asset-class-table .table-row.benchmark-row .numeric-value {
+.asset-class-table .asset-table-row.benchmark-row .numeric-value {
   font-weight: 700;
 }
 
@@ -936,11 +936,11 @@
   }
   
   .asset-class-table .table-header th,
-  .asset-class-table .table-cell {
+  .asset-class-table .asset-table-cell {
     padding: 16px 20px;
   }
   
-  .asset-class-table .table-cell {
+  .asset-class-table .asset-table-cell {
     height: 72px;
   }
 }
@@ -999,11 +999,11 @@
   }
   
   .asset-class-table .table-header th,
-  .asset-class-table .table-cell {
+  .asset-class-table .asset-table-cell {
     padding: 12px 16px;
   }
   
-  .asset-class-table .table-cell {
+  .asset-class-table .asset-table-cell {
     height: 64px;
   }
   
@@ -1096,12 +1096,12 @@
   color: var(--text-default);
 }
 
-.visual-refresh .asset-class-table .table-cell {
+.visual-refresh .asset-class-table .asset-table-cell {
   padding: calc(var(--spacing-sm)) calc(var(--spacing-md));
   border-bottom: 1px solid var(--border-color);
 }
 
-.visual-refresh .asset-class-table .table-cell:hover {
+.visual-refresh .asset-class-table .asset-table-cell:hover {
   background-color: color-mix(in srgb, var(--surface-bg) 85%, var(--btn-primary-bg));
 }
 
@@ -1161,7 +1161,7 @@
 } 
 
 /* Visual Refresh Compact Mode Support */
-.visual-refresh.density-compact .asset-class-table .table-cell { 
+.visual-refresh.density-compact .asset-class-table .asset-table-cell { 
   padding: 6px 10px; 
 }
 

--- a/src/components/Dashboard/AssetClassTable.jsx
+++ b/src/components/Dashboard/AssetClassTable.jsx
@@ -502,13 +502,13 @@ const AssetClassTable = ({
                   <tr
                     key={row.ticker || index}
                     className={`
-                      table-row transition-all duration-200 hover:bg-gray-50
+                      asset-table-row transition-all duration-200 hover:bg-gray-50
                       ${isBenchmark ? 'benchmark-row' : ''}
                       ${isRecommended ? 'recommended-row' : ''}
                     `}
                   >
                     {/* Fund Column */}
-                    <td className="table-cell px-6 py-4">
+                    <td className="asset-table-cell px-6 py-4">
                       <div className="fund-info-container">
                         {/* Status Indicator Container - Fixed width */}
                         <div className="status-indicator-container">
@@ -536,28 +536,28 @@ const AssetClassTable = ({
                     </td>
 
                     {/* Score Column */}
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderScoreBadge(getFieldValue(row, 'score_final', ['score', 'final_score']))}
                     </td>
 
                     {/* Return Columns */}
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderReturn(getFieldValue(row, 'ytd_return', ['ytd', 'Total Return - YTD (%)']), 'YTD')}
                     </td>
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderReturn(getFieldValue(row, 'one_year_return', ['1 Year', 'Total Return - 1 Year (%)']), '1Y')}
                     </td>
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderReturn(getFieldValue(row, 'three_year_return', ['3 Year', 'Annualized Total Return - 3 Year (%)']), '3Y')}
                     </td>
 
                     {/* Expense Ratio */}
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderExpenseRatio(getFieldValue(row, 'expense_ratio', ['Net Exp Ratio (%)']))}
                     </td>
 
                     {/* Sharpe Ratio */}
-                    <td className="table-cell px-6 py-4 text-center">
+                    <td className="asset-table-cell px-6 py-4 text-center">
                       {renderSharpeRatio(getFieldValue(row, 'sharpe_ratio', ['Sharpe Ratio - 3 Year', 'Sharpe Ratio']))}
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- prevent SimplifiedDashboard's global `.table-row` grid rule from affecting AssetClassTable
- rename table-row/table-cell classes to asset-table-row/asset-table-cell

## Testing
- `npm test -- --watchAll=false` *(fails: Test Suites: 11 failed, 54 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af132176d08329ae4b32c714a5f419